### PR TITLE
Readme update to use RVM instead of "sudo install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,25 @@ View the page at [Azkaban Github Page](http://azkaban.github.io/).
 View the site Locally
 ========
 
-One time setup
+One time setup:
 
-    sudo gem install bundler
+It is **highly recommended** to use RVM for creating an isolated Ruby environment before installing packages.
+Using RVM will prevent possible conflicts with the default Ruby interpreter that comes with your OS.  
+Information for installing RVM can be found (here)[https://rvm.io/rvm/install] and basic usage 
+is found (here)[https://rvm.io/rvm/basics].
 
-    sudo gem install pygments.rb
+The following instructions presume that RVM is installed and will create an isolate environment 
+before downloading needed dependencies from the Internet.
 
-    bundle install
+    $ rvm gemset create azkaban.gethub.io
+    $ rvm gemset use azkaban.gethub.io
+    $ gem install bundler
+    $ bundle install
 
-Run the command
+To start a local jekyll server, run the following within your RVM environment.
 
-	bundle exec jekyll serve -P 4001
+	  $ bundle exec jekyll serve -P 4001
 
-Then view the page at http://localhost:4001.
+Then visit http://localhost:4001 to view the locally rendered content.
 
-More information [here](https://help.github.com/articles/using-jekyll-with-pages/)
+More information about jekyll is [here](https://help.github.com/articles/using-jekyll-with-pages/)


### PR DESCRIPTION
This is an update to the readme, recommending people use RVM before downloading Ruby dependancies when rendering content locally. 